### PR TITLE
change deletion to be id based instead of being hostname based

### DIFF
--- a/optica.rb
+++ b/optica.rb
@@ -79,8 +79,8 @@ class Optica < Sinatra::Base
     return 'stored'
   end
 
-  delete '/:hostname' do |hostname|
-    matching = settings.store.nodes.select{ |k,v| v['hostname'] == hostname }
+  delete '/:id' do |id|
+    matching = settings.store.nodes.select{ |k,v| v['id'] == id }
     if matching.length == 0
       return 204
     elsif matching.length == 1
@@ -92,7 +92,7 @@ class Optica < Sinatra::Base
         return "deleted"
       end
     else
-      return [409, "found multiple entries matching hostname #{hostname}"]
+      return [409, "found multiple entries matching id #{id}"]
     end
   end
 


### PR DESCRIPTION
@igor47 
Changes the deletion to be based on the id, because the hostname might not be set correctly and other systems consider the hostname and the id to be identical, but it is not always the case. Since external systems my be getting ids from AWS and use them directly against optica as hostname, that creates some errors when the hostname and the id are different.
