### PR TITLE
Pass event data to rabbitmq

### DIFF
--- a/optica.rb
+++ b/optica.rb
@@ -70,7 +70,7 @@ class Optica < Sinatra::Base
 
     begin
       merged_data = settings.store.add(ip, data)
-      settings.events.send(merged_data)
+      settings.events.send(merged_data.merge("event" => data))
     rescue
       halt(500)
     end


### PR DESCRIPTION
This passes event data through to rabbitmq for consumers to be able to read it before it's merged.
