### PR TITLE
Make optica more robust in the event of rabbitmq failure

### DIFF
--- a/events.rb
+++ b/events.rb
@@ -35,7 +35,6 @@ class Events
     @client.publish("/exchange/#{@exchange_name}/#{@routing}", data.to_json, {:persistent => true})
   rescue Exception => e
     @log.error "unexpected error publishing to rabbitmq: #{e.inspect}"
-    stop
     raise e
   else
     @log.debug "published an event to #{@routing}"

--- a/optica.rb
+++ b/optica.rb
@@ -76,18 +76,15 @@ class Optica < Sinatra::Base
     end
 
     # publish update event
-    error_msg = ""
+    message = 'stored'
     begin
       settings.events.send(merged_data.merge("event" => data))
     rescue => e
-      error_msg = e.to_s
+      # If event publishing failed, we treat it as a warning rather than an error.
+      message += " -- [warning] failed to publish to rabbitmq: #{e.to_s}"
     end
 
     content_type 'text/plain', :charset => 'utf-8'
-
-    # If event publishing failed, we treat it as a warning rather than an error.
-    message = 'stored'
-    message += " -- [warning] failed to publish to rabbitmq: #{error_msg}" if error_msg != ""
 
     return message
   end

--- a/optica.rb
+++ b/optica.rb
@@ -79,7 +79,7 @@ class Optica < Sinatra::Base
     error_msg = ""
     begin
       settings.events.send(merged_data.merge("event" => data))
-    rescue Exception => e
+    rescue => e
       error_msg = e.to_s
     end
 


### PR DESCRIPTION
Summary:
In the Dec 18 2014 Incident where Optica was down because of RabbitMQ. However, failing to publishing updates to RabbitMQ in Optica should not bring the whole Optica down.

This diff makes publishing failure as a warning rather than an error.

Test Plan:

Before:

* shutdown local rabbitmq after server startup
* post message to local optica, which triggers Events.send().
* since rabbitmq server is not available, an exception was thrown and halt the whole process.

After:

* shutdown local rabbitmq after server startup
* post message to local optica
* the process remail alive, with the error message sent to the client: `stored -- [warning] failed to publish to rabbitmq: Unable to connect rabbitmq server`

Signed-off-by: Kai Liu <kai.liu@airbnb.com>