### PR TITLE
Add cache support.

### DIFF
--- a/store.rb
+++ b/store.rb
@@ -16,6 +16,35 @@ class Store
     end
 
     @zk = nil
+    setup_cache(opts)
+  end
+
+  def setup_cache(opts)
+    # We use a daemon that refreshes cache every N (tunable)
+    # seconds. In addition, we subscript to all children joining/leaving
+    # events. This is less frequent because normally no one would constantly
+    # add/remove machines. So whenever a join/leave event happens, we immediately
+    # refresh cache. This way we guarantee that whenever we add/remove
+    # machines, cache will always have the right set of machines.
+
+    @cache_enabled = !!opts['cache_enabled']
+
+    # zk watcher for node joins/leaves
+    @cache_root_watcher = nil
+
+    # mutex for atomically updating cached results
+    @cache_mutex = Mutex.new
+    @cache_results = {}
+
+    # daemon that'll fetch from zk periodically
+    @cache_fetch_thread = nil
+    # flag that controls if fetch daemon should run
+    @cache_fetch_thread_should_run = false
+    # how long we serve cached data
+    @cache_fetch_interval = (opts['cache_fetch_interval'] || 20).to_i
+
+    # timestamp that prevents setting cache result with stale data
+    @cache_results_last_fetched_time = Time.now
   end
 
   def start()
@@ -26,23 +55,47 @@ class Store
     end
     @zk.ping?
     @log.info "ZK connection established successfully. session_id=#{session_id}"
+
+    if @cache_enabled then
+      watch
+      reload_instances
+      start_fetch_thread
+    end
   end
 
   def session_id
     '0x%x' % @zk.session_id rescue nil
   end
 
-  def stop()
-    @log.warn "stopping the store"
-    Process.kill("TERM", Process.pid) unless $EXIT
-    @zk.close() if @zk
+  def stop_cache_related()
+    @cache_root_watcher.unsubscribe if @cache_root_watcher
+    @cache_root_watcher = nil
+    @cache_fetch_thread_should_run = false
+    @cache_fetch_thread.join if @cache_fetch_thread
+    @cache_fetch_thread = nil
   end
 
+  def stop()
+    @log.warn "stopping the store"
+    stop_cache_related
+    @zk.close() if @zk
+    @zk = nil
+  end
+
+  # get instances for a given service
   def nodes()
+    STATSD.time('optica.store.get_nodes') do
+      return load_instances_from_zk unless @cache_enabled
+      @cache_results.clone
+    end
+  end
+
+  def load_instances_from_zk()
+    @log.info "Reading instances from zk:"
     from_server = {}
 
     begin
-      @zk.children('/').each do |child|
+      @zk.children('/', :watch => true).each do |child|
         from_server[child] = get_node("/#{child}")
       end
     rescue Exception => e
@@ -126,6 +179,50 @@ class Store
     rescue Exception => e
       @log.error "unexpected error reading from zk! #{e.inspect}"
       raise e
+    end
+  end
+
+  # immediately update cache if node joins/leaves
+  def watch()
+    return if @zk.nil?
+    @cache_root_watcher ||= @zk.register("/", :only => :child) do |event|
+      @log.info "Children added/deleted"
+      reload_instances
+    end
+  end
+
+  def reload_instances()
+    # Here we use local time to preven race condition
+    # Basically cache fetch thread or zookeeper watch callback
+    # both will call this to refresh cache. Depending on which
+    # finishes first our cache will get set by the slower one.
+    # So in order to prevent setting cache to an older result,
+    # we set both cache and the timestamp of that version fetched
+    # Since timestamp will be monotonically increasing, we are
+    # sure that cache set will always have newer versions
+
+    fetch_start_time = Time.now
+    instances = load_instances_from_zk()
+    @cache_mutex.synchronize do
+      if fetch_start_time > @cache_results_last_fetched_time then
+        @cache_results_last_fetched_time = fetch_start_time
+        @cache_results = instances
+      end
+    end
+  end
+
+  def start_fetch_thread()
+    @cache_fetch_thread_should_run = true
+    @cache_fetch_thread = Thread.new do
+      while @cache_fetch_thread_should_run do
+        begin
+          sleep(@cache_fetch_interval) rescue nil
+          @log.info "Cache fetch thread now fetches from zk..."
+          reload_instances rescue nil
+        rescue => ex
+          @log.warn "Caught exception in cache fetch thread: #{ex} #{ex.backtrace}"
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Right now for every single query we go to zk and fetch all children
data then do an in-mem filtering. When we have thousands of children
this becomes a very expensive operation. This PR adds an optional
feature of caching fetched result from zk. The way this cache is
implemented is a compromise between consistency and complexity.

Ideally to make cache 100% consistent we should subcribe to every
single change to children's data. However, in reality this is
inpractical because it's possible there could be children updates
all the time due to periodical jobs.

So this PR uses a daemon that refreshes cache every N (tunable)
seconds. In addition, we subscript to all children joining/leaving
events. This is less frequent because normally no one would constantly
add/remove machines. So whenever a join/leave event happens, we immediately
refresh a cache. This way we guarantee that whenever we add/remove
machines, cache will always have the right set of machines.