### PR TITLE
[fab] add a faster endpoint for fab usage

### DIFF
--- a/optica.rb
+++ b/optica.rb
@@ -8,6 +8,15 @@ class Optica < Sinatra::Base
   end
 
   get '/' do
+    return get_nodes(request, true)
+  end
+
+  # endpoint for fab usage
+  get '/roles' do
+    return get_nodes(request, false)
+  end
+
+  def get_nodes(request, is_full_node)
     params = CGI::parse(request.query_string)
 
     # include only those nodes that match passed-in parameters
@@ -41,7 +50,9 @@ class Optica < Sinatra::Base
         end
       end
 
-      to_return[node] = properties if included
+      if included
+        to_return[node] = is_full_node ? properties : properties.slice(:role, :id, :hostname) 
+      end
     end
 
     content_type 'application/json', :charset => 'utf-8'

--- a/optica.rb
+++ b/optica.rb
@@ -8,15 +8,16 @@ class Optica < Sinatra::Base
   end
 
   get '/' do
-    return get_nodes(request, true)
+    return get_nodes(request)
   end
 
   # endpoint for fab usage
   get '/roles' do
-    return get_nodes(request, false)
+    # keys must be strings
+    return get_nodes(request, ['role', 'id', 'hostname'])
   end
 
-  def get_nodes(request, is_full_node)
+  def get_nodes(request, fields_to_include=nil)
     params = CGI::parse(request.query_string)
 
     # include only those nodes that match passed-in parameters
@@ -51,7 +52,10 @@ class Optica < Sinatra::Base
       end
 
       if included
-        to_return[node] = is_full_node ? properties : properties.slice(:role, :id, :hostname) 
+        # return full list if fields_to_include is nil. Otherwise return only keys
+        # listed in fields_to_include. Not using slice because not a rails app. 
+        to_return[node] = fields_to_include.nil? ? properties : properties
+          .select { |key, _value| fields_to_include.include? key }
       end
     end
 

--- a/tools/fabfile.py
+++ b/tools/fabfile.py
@@ -4,7 +4,7 @@ import collections
 import json
 import requests
 
-response  = requests.get('http://%s:8080/' % optica_ip)
+response  = requests.get('http://%s:8080/roles' % optica_ip)
 hosts     = json.loads(response.text)
 
 # fill the role list


### PR DESCRIPTION
Add a smaller endpoint that only returns the role info for fab, and possibly other programmatic usage. This makes the resulting json easier/faster to parse for fab and others. 

@igor47 @jtai 