### PR TITLE
Add option when bundle installing to include newrelic_rpm

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,5 +4,6 @@ gem 'sinatra',         '~> 1.4.4'
 gem 'zk',              '~> 1.9.3'
 gem 'unicorn',         '~> 4.8.3'
 gem 'hash-deep-merge', '~> 0.1.1'
+gem 'newrelic_rpm',    '~> 3.18.1', group: :newrelic
 gem 'stomp',           '~> 1.3.2'
 gem 'statsd-ruby',     '~> 1.2.1'

--- a/config.ru
+++ b/config.ru
@@ -59,5 +59,11 @@ Optica.set :store, store
 Optica.set :events, events
 Optica.set :ip_check, ip_check
 
+begin
+    require 'newrelic_rpm'
+rescue LoadError
+    log.info "Newrelic not found, skipping..."
+end
+
 log.info "Starting sinatra server..."
 run Optica


### PR DESCRIPTION
`bundle install --with newrelic` will now install the newrelic_rpm gem
We will now also optimistically try to load the library.