### PR TITLE
[enhancement] Add unicorn-worker-killer to recycle unicorn workers

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,9 +1,10 @@
 source 'https://rubygems.org'
 
-gem 'sinatra',         '~> 1.4.4'
-gem 'zk',              '~> 1.9.3'
-gem 'unicorn',         '~> 4.8.3'
-gem 'hash-deep-merge', '~> 0.1.1'
-gem 'newrelic_rpm',    '~> 3.18.1', group: :newrelic
-gem 'stomp',           '~> 1.3.2'
-gem 'statsd-ruby',     '~> 1.2.1'
+gem 'sinatra',               '~> 1.4.4'
+gem 'zk',                    '~> 1.9.3'
+gem 'unicorn',               '~> 4.8.3'
+gem 'unicorn-worker-killer', '~> 0.4.4'
+gem 'hash-deep-merge',       '~> 0.1.1'
+gem 'newrelic_rpm',          '~> 3.18.1', group: :newrelic
+gem 'stomp',                 '~> 1.3.2'
+gem 'statsd-ruby',           '~> 1.2.1'

--- a/config.ru
+++ b/config.ru
@@ -16,6 +16,25 @@ STATSD = Statsd.new(opts['statsd_host'], opts['statsd_port'])
 # prepare to exit cleanly
 $EXIT = false
 
+# configure unicorn-worker-killer
+if opts['worker_killer']
+  require 'unicorn/worker_killer'
+
+  wk_opts = opts['worker_killer']
+
+  if wk_opts['max_requests']
+    max_requests = wk_opts['max_requests']
+    # Max requests per worker
+    use Unicorn::WorkerKiller::MaxRequests, max_requests['min'], max_requests['max']
+  end
+
+  if wk_opts['mem_limit']
+    mem_limit = wk_opts['mem_limit']
+    # Max memory size (RSS) per worker
+    use Unicorn::WorkerKiller::Oom, mem_limit['min'], mem_limit['max']
+  end
+end
+
 # configure the store
 require './store.rb'
 store = Store.new(opts)


### PR DESCRIPTION
Add options to enable and configure unicorn-worker-killer via config.json:

```json
{
...
  "worker_killer": {
    "max_requests": {
      "min": 100000,
      "max": 110000
    },
    "mem_limit": {
      "min": 1048576,
      "max": 2097152
    }
  }
...
}