### PR TITLE
Lock oj gem version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ gem 'zk',                    '~> 1.9.3'
 gem 'unicorn',               '~> 4.8.3'
 gem 'unicorn-worker-killer', '~> 0.4.4'
 gem 'hash-deep-merge',       '~> 0.1.1'
-gem 'oj',                    '~> 3.3.2'
+gem 'oj',                    '= 3.3.2'
 gem 'stomp',                 '~> 1.3.2'
 gem 'statsd-ruby',           '~> 1.2.1'
 


### PR DESCRIPTION
Latest oj 3.3.x version requires ruby2.0 which breaks deploy. Locking it down to 3.3.2 to work around this issue.

@darnaut 