### PR TITLE
get_process_mem set version to avoid crash

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,7 @@ gem 'oj',                    '= 3.3.2'
 gem 'stomp',                 '~> 1.3.2'
 gem 'dogstatsd-ruby',        '= 3.3.0'
 gem 'aws-sdk-sqs',           '= 1.3.0'
+gem 'get_process_mem',       '= 0.2.1'
 
 group :newrelic do
   gem 'newrelic_rpm',          '~> 3.18.1'


### PR DESCRIPTION
Pin get_process_mem to version that works.

Problem:
```
2018-11-05T19:00:00.094040+00:00 localhost.localdomain user.notice E, - [2018-11-05T19:00:00.093860 #11434] ERROR -- : nil is not a symbol (TypeError)
2018-11-05T19:00:00.094066+00:00 localhost.localdomain user.notice /var/lib/gems/1.9.1/gems/get_process_mem-0.2.3/lib/get_process_mem.rb: - 9:in `private_class_method'
2018-11-05T19:00:00.094066+00:00 localhost.localdomain user.notice /var/lib/gems/1.9.1/gems/get_process_mem-0.2.3/lib/get_process_mem.rb: - 9:in `<class:GetProcessMem>'
2018-11-05T19:00:00.094099+00:00 localhost.localdomain user.notice /var/lib/gems/1.9.1/gems/get_process_mem-0.2.3/lib/get_process_mem.rb: - 5:in `<top (required)>'
2018-11-05T19:00:00.094119+00:00 localhost.localdomain user.notice /usr/lib/ruby/1.9.1/rubygems/custom_require.rb: - 36:in `require'
2018-11-05T19:00:00.094156+00:00 localhost.localdomain user.notice /usr/lib/ruby/1.9.1/rubygems/custom_require.rb: - 36:in `require'
2018-11-05T19:00:00.094182+00:00 localhost.localdomain user.notice /var/lib/gems/1.9.1/gems/unicorn-worker-killer-0.4.4/lib/unicorn/worker_killer.rb: - 2:in `<top (required)>'
```


Test: bundle install works