### PR TITLE
Allow configuration of Rack's key_space_limit

### DIFF
--- a/config.ru
+++ b/config.ru
@@ -18,6 +18,12 @@ if opts['gc_stats']
   end
 end
 
+# Rack options
+if opts['rack']
+  key_space_limit = opts['rack']['key_space_limit']
+  Rack::Utils.key_space_limit = key_space_limit if key_space_limit
+end
+
 # prepare statsd
 require 'datadog/statsd'
 STATSD = Datadog::Statsd.new(opts['statsd_host'], opts['statsd_port'])


### PR DESCRIPTION
They [key_space_limit](https://github.com/rack/rack/#key_space_limit-) controls the number of bytes to allow all parameters keys in a given parameter hash to take up.

The default value is `65536` which is not enough to handle large objects (> `65536`) being posted to Optica.