### PR TITLE
Multiple changes

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,11 +11,6 @@ gem 'dogstatsd-ruby',        '= 3.3.0'
 gem 'aws-sdk-sqs',           '= 1.3.0'
 gem 'get_process_mem',       '= 0.2.1'
 
-group :newrelic do
-  gem 'newrelic_rpm',          '~> 3.18.1'
-  gem 'newrelic-zookeeper',    '~> 1.0.0'
-end
-
 group :ddtrace do
   gem 'ddtrace', '~> 0.45.0'
 end


### PR DESCRIPTION
- Implement "split mode" that allows to run optica's cache instance in a separate process. Running optica in split mode results in significant reduction in CPU utilization on the optica instances, as well as reduction in workload that optica adds to Zookeeper cluster.
- Implement secondary index support. Previously, every request to optica would scan its entire dataset. This change allows to provide a list of fields to use as secondary keys, which can significantly improve performance of specific queries. 
- Change reload_instances function such that it does full reload of cache only at specific intervals.
- Drop newrelic support
