### PR TITLE
Upgraded zk dependency to 1.10.0 for M1 compatibility

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source 'https://rubygems.org'
 
 gem 'sinatra',               '~> 1.4.4'
-gem 'zk',                    '~> 1.9.3'
+gem 'zk',                    '~> 1.10.0'
 gem 'unicorn',               '~> 4.8.3'
 gem 'unicorn-worker-killer', '~> 0.4.4'
 gem 'hash-deep-merge',       '~> 0.1.1'


### PR DESCRIPTION
Upgraded `zk` to latest version so `bundle install` works on M1 macs.